### PR TITLE
chore: add React and Node type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "react-dom": "latest"
   },
   "devDependencies": {
-    "typescript": "^5.2.0"
+    "typescript": "^5.2.0",
+    "@types/react": "latest",
+    "@types/node": "latest"
   }
 }


### PR DESCRIPTION
This hotfix adds missing React and Node type definitions to devDependencies, which resolves build errors when using TypeScript in Next.js. This ensures the application builds successfully on Vercel.